### PR TITLE
fix: concurrency protection

### DIFF
--- a/execs.flow
+++ b/execs.flow
@@ -26,15 +26,14 @@ executables:
         - envKey: TERM
           text: xterm-256color
       execs:
-        # TODO: Add -race flag when the container becomes thread safe
         - cmd: |
             set -e
             echo "Running Go unit tests..."
             if [ "$CI" = "true" ]; then
               echo "Running Go unit tests with coverage..."
-              go test -coverprofile=coverage.out -covermode=atomic ./...
+              go test -race -coverprofile=coverage.out -covermode=atomic ./...
             else
-              go test ./...
+              go test -race ./...
             fi
             echo "Unit tests completed"
           retries: 3

--- a/views/form.go
+++ b/views/form.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
@@ -119,6 +120,7 @@ type Form struct {
 	completed bool
 
 	in, out *os.File
+	mu      sync.RWMutex
 }
 
 // NewForm creates a new form model that can be run in a Bubble Tea program. It includes some extra handling
@@ -228,10 +230,15 @@ func (f *Form) Completed() bool {
 }
 
 func (f *Form) Init() tea.Cmd {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return f.form.Init()
 }
 
 func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	if f.err != nil {
 		return f.err.Update(msg)
 	}
@@ -260,6 +267,9 @@ func (f *Form) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (f *Form) View() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	if f.err != nil {
 		return f.err.View()
 	}

--- a/views/markdown.go
+++ b/views/markdown.go
@@ -2,6 +2,7 @@ package views
 
 import (
 	"math"
+	"sync"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,6 +18,7 @@ type MarkdownView struct {
 	err           *ErrorView
 	theme         themes.Theme
 	width, height int
+	mu            sync.RWMutex
 }
 
 func NewMarkdownView(state *types.RenderState, content string) *MarkdownView {
@@ -30,10 +32,15 @@ func NewMarkdownView(state *types.RenderState, content string) *MarkdownView {
 }
 
 func (v *MarkdownView) Init() tea.Cmd {
+	v.mu.Lock()
+	defer v.mu.Unlock()
 	return v.viewport.Init()
 }
 
 func (v *MarkdownView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
 	if v.err != nil {
 		return v.err.Update(msg)
 	}
@@ -57,6 +64,9 @@ func (v *MarkdownView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (v *MarkdownView) View() string {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
 	mdStyles, err := v.theme.GlamourMarkdownStyleJSON()
 	if err != nil {
 		v.err = NewErrorView(err, v.theme)


### PR DESCRIPTION
Introduce thread-safety improvements across multiple components by adding `sync.RWMutex` for managing concurrent access to shared state. It also updates the test configuration to enable the `-race` flag, ensuring race conditions are detected during testing.